### PR TITLE
Add New Method for Reading Fund Details, Switch to JSON Parsing, and Extend .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,18 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 cover/
+
+# Editor
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,12 @@ __pycache__/
 # Sphinx documentation
 docs/_build/*
 *.pyc
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/

--- a/mstarpy/funds.py
+++ b/mstarpy/funds.py
@@ -108,6 +108,51 @@ class Funds(Security):
         return self.GetData("parent/analystRating/topfundsUpDown")
 
 
+
+    def keyStats(self):
+        """
+        This function retrieves the key status information of the funds, index, category or the annual rank of the funds.
+
+        Returns:
+            dict annual performance or rank
+
+        Raises:
+            ValueError : raised whenever parameter cat is not category, funds, index, or rank
+
+        Examples:
+            >>> Funds("myria", "fr").key_stats()
+
+        """
+        #headers random agent
+        headers = {'user-agent' : random_user_agent()}
+        #page 1 - performance
+        url = f"{self.site}funds/snapshot/snapshot.aspx?id={self.code}"
+        
+        response = requests.get(url, headers=headers, proxies=self.proxies)
+        not_200_response(url,response)
+        soup = BeautifulSoup(response.text, 'html.parser')
+       
+        table_rows = soup.find(id="overviewQuickstatsDiv").find_all('tr')
+        details = []
+        for row in table_rows:
+            key, value, date_stamp = None, None, None
+            for cell in row.find_all("td"):
+                if cell.has_attr("class"):
+                    if "line" in cell["class"]:
+                        if "heading" in cell["class"]:
+                            key = cell.get_text(separator = "\n", strip = True)
+                            if "\n" in key:
+                                key, date_stamp = key.split("\n")
+                        if "text" in cell["class"]:
+                            value = cell.text
+            if key and value and date_stamp:
+                details.append({key: value, "date": date_stamp})
+            elif key and value:
+                details.append({key: value})
+
+        return details
+
+
     def AnnualPerformance(self, cat):
         """
         This function retrieves the annual performance of the funds, index, category or the annual rank of the funds.

--- a/mstarpy/search.py
+++ b/mstarpy/search.py
@@ -102,7 +102,7 @@ def general_search(params, proxies={}):
 
   not_200_response(url, response)
     
-  return json.loads(response.content.decode())
+  return response.json()
 
 
 def search_field(pattern = ''):

--- a/mstarpy/security.py
+++ b/mstarpy/security.py
@@ -172,7 +172,7 @@ class Security:
 
         not_200_response(url,response)
 
-        return json.loads(response.content.decode()) 
+        return response.json()
     
     def ltData(self,field,currency="EUR"):
         """
@@ -211,7 +211,7 @@ class Security:
         not_200_response(url,response)
 
         #responseis a list
-        response_list = json.loads(response.content.decode()) 
+        response_list = response.json() 
         if response_list:
             return response_list[0]
         else:
@@ -289,7 +289,7 @@ class Security:
         #manage response
         not_200_response(url,response)
         #result
-        result =json.loads(response.content.decode())
+        result = response.json()
         #return empty list if we don't get data
         if not result:
             return []

--- a/mstarpy/utils.py
+++ b/mstarpy/utils.py
@@ -599,7 +599,7 @@ SITE = {
         'ug' : {'iso3' : 'UGA', 'site' : ''},
         'ua' : {'iso3' : 'UKR', 'site' : ''},
         'ae' : {'iso3' : 'ARE', 'site' : ''},
-        'gb' : {'iso3' : 'GBR', 'site' : ''},
+        'gb' : {'iso3' : 'GBR', 'site' : 'https://www.morningstar.co.uk/uk/'},
         'um' : {'iso3' : 'UMI', 'site' : ''},
         'us' : {'iso3' : 'USA', 'site' : 'https://www.morningstar.com/'},
         'uy' : {'iso3' : 'URY', 'site' : ''},


### PR DESCRIPTION
The main additions include a new method to read fund details from HTML, switching to JSON parsing using a provided method from the requests library, adding a new UK URL, and extending the .gitignore file to include additional files.